### PR TITLE
Feature/firebase-hosting

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "spajam-b508a"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,26 @@
 # Specifies intentionally untracked files to ignore when using Git
 # http://git-scm.com/docs/gitignore
 
+# generals
 *~
 *.sw[mnpcod]
 *.log
 *.tmp
 *.tmp.*
 log.txt
+
+# editor preferences
 *.sublime-project
 *.sublime-workspace
 .vscode/
 npm-debug.log*
 
+# additionals
 .env.dev
 .env.prod
+.firebase/
 
+# ionic defaults
 .idea/
 .ionic/
 .sourcemaps/
@@ -33,6 +39,7 @@ plugins/ios.json
 www/
 $RECYCLE.BIN/
 
+# polluting files
 .DS_Store
 Thumbs.db
 UserInterfaceState.xcuserstate

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,16 @@
+{
+  "hosting": {
+    "public": "www",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
fix: #10 

## 変更点：
`firebase deploy`で、`www/`以下の静的ファイルをデプロイし、firebaseが自動的にホスティングしてくれるようになりました。
domain: `spajam-b508a.firebaseapp.com`

注意点
1. CLIでログインしているfirebaseアカウントが、project: `spajam-b508a`に追加されている場合、デプロイできるはず。。
2. デプロイは、すでにビルドされている静的ファイルをfirebaseに展開します。環境変数もビルドに込み込みなので同時に持っていってくれますが、`env.dev`と`env.prod`のどちらを使っているかに気をつけて！